### PR TITLE
Adds scenario for exception message.

### DIFF
--- a/lib/capybara/ui.rb
+++ b/lib/capybara/ui.rb
@@ -35,7 +35,7 @@ module Capybara
     end
 
     def self.subclass_for_page(page)
-      subclasses.detect { |s| s.matches?(page) } || (raise NoMatch)
+      subclasses.detect { |s| s.matches?(page) } || (raise NoMatch.new(%(No Capybara::UI class defined for path "#{page.current_path}")))
     end
 
     def self.find_session(&block)

--- a/spec/features/capybara_spec.rb
+++ b/spec/features/capybara_spec.rb
@@ -47,4 +47,12 @@ feature "Capybara" do
 
     expect(ui.class).to eq(FooPage)
   end
+
+  scenario "Visiting a page that doesn't have a Capybara-ui matcher" do
+    page.reset!
+
+    visit "/baz.html"
+    expect{ ui }.to raise_error(Capybara::UI::NoMatch, %(No Capybara::UI class defined for path "/baz.html"))
+  end
 end
+


### PR DESCRIPTION
- Ploppping capybara-ui blindly into a project, I was shown:
  "Capybara::UI::NoMatch"
  which wasn't intuitive without digging into the code.
- This patch adds a better message to the NoMatch exception.
